### PR TITLE
Drop owner field

### DIFF
--- a/apple-ibridge.c
+++ b/apple-ibridge.c
@@ -567,7 +567,6 @@ MODULE_DEVICE_TABLE(acpi, appleib_acpi_match);
 static struct acpi_driver appleib_driver = {
 	.name		= "apple-ibridge",
 	.class		= "topcase", /* ? */
-	.owner		= THIS_MODULE,
 	.ids		= appleib_acpi_match,
 	.ops		= {
 		.add		= appleib_probe,


### PR DESCRIPTION
The owner field was removed from struct acpi_driver in Linux v6.10-rc1, see commit [cc85f9c05bba ("ACPI: drop redundant owner from acpi_driver")](https://github.com/torvalds/linux/commit/cc85f9c05bba).